### PR TITLE
Remove `cml publish` pipe from examples

### DIFF
--- a/.github/workflows/cml.yaml
+++ b/.github/workflows/cml.yaml
@@ -25,10 +25,11 @@ jobs:
           dvc plots diff \
             --target output/predictions.json \
             --show-vega > vega.json
-          vl2png vega.json -s 1.5 | cml-publish --md >> report.md
+          vl2png vega.json -s 1.5 > plot.png
+          cml publish --md plot.png >> report.md
           # Add figure to report
           cat output/metrics.json >> report.md
-          cml-send-comment report.md
+          cml send-comment report.md
 
       - name: Commit files
         id: commit


### PR DESCRIPTION
Closes https://github.com/iterative/cml/issues/1000 along with all the pull requests listed in https://github.com/iterative/cml/issues/1000#issuecomment-1124628318